### PR TITLE
Updates and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ env
 *.pyc
 cms/db.sqlite3
 geckodriver.log
+ghostdriver.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ env
 .DS_Store
 *.pyc
 cms/db.sqlite3
+geckodriver.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8
 -e git://github.com/divio/djangocms-admin-style.git@e881c6b1a4d40beb23f4357a7b974649d1e80942#egg=djangocms_admin_style-master
 egat==1.0.1
-selenium==2.45.0
+selenium==3.141.0
 wsgiref==0.1.2

--- a/tests/test_configs/advanced_login_config.json
+++ b/tests/test_configs/advanced_login_config.json
@@ -14,10 +14,6 @@
   "environments": [
     {
         "browser_location": "local",
-        "browser": "Firefox"
-    },
-    {
-        "browser_location": "local",
         "browser": "Chrome"
     }
   ]

--- a/tests/test_configs/dev_config.json
+++ b/tests/test_configs/dev_config.json
@@ -40,10 +40,6 @@
   "environments": [
     {
         "browser_location": "local",
-        "browser": "Firefox"
-    },
-    {
-        "browser_location": "local",
         "browser": "Chrome"
     }
   ]

--- a/tests/test_configs/suite.json
+++ b/tests/test_configs/suite.json
@@ -40,12 +40,7 @@
   "environments": [
     {
         "browser_location": "local",
-        "browser": "Firefox"
-    },
-    {
-        "browser_location": "local",
         "browser": "Chrome"
     }
   ]
 }
-

--- a/tests/test_configs/test_customers_config.json
+++ b/tests/test_configs/test_customers_config.json
@@ -21,10 +21,6 @@
   "environments": [
     {
         "browser_location": "local",
-        "browser": "Firefox"
-    },
-    {
-        "browser_location": "local",
         "browser": "Chrome"
     }
   ]

--- a/tests/test_configs/test_orders_config.json
+++ b/tests/test_configs/test_orders_config.json
@@ -25,10 +25,6 @@
   "environments": [
     {
         "browser_location": "local",
-        "browser": "Firefox"
-    },
-    {
-        "browser_location": "local",
         "browser": "Chrome"
     }
   ]

--- a/tests/test_configs/test_payment_config.json
+++ b/tests/test_configs/test_payment_config.json
@@ -23,12 +23,7 @@
   "environments": [
     {
         "browser_location": "local",
-        "browser": "Firefox"
-    },
-    {
-        "browser_location": "local",
         "browser": "Chrome"
     }
   ]
 }
-

--- a/tests/test_helpers/browser_helper.py
+++ b/tests/test_helpers/browser_helper.py
@@ -47,6 +47,6 @@ def get_browser(environment):
         elif environment.get('browser', '') == "PhantomJS":
             return webdriver.PhantomJS()
         elif environment.get('browser', '') == "Safari":
-            return webdriver.Safari
+            return webdriver.Safari()
         else:
             return webdriver.Firefox()


### PR DESCRIPTION
Lumped several things in here.
Updated the requirement to the latest selenium 3.114.0.
Fixed a bug in the browser_helper.py where the open and close parens were not provided for the Safari case.
Added a couple files to gitignore, for geckodriver and phantomjs ghostdriver.
Removed all instances of Firefox in our test suite, until Selenium and-or geckodriver are updated to support a more recent version of Firefox.